### PR TITLE
Add React v18 to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "url": "https://github.com/asnunes/mathjax3-react"
   },
   "peerDependencies": {
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react": "^17.0.2 || ^18.2.0",
+    "react-dom": "^17.0.2 || ^18.2.0"
   },
   "dependencies": {
     "simple-load-script": "^1.0.3"


### PR DESCRIPTION
This patch relaxes the mathjax3-react peer dependencies to allow React v18 in addition to v17. 

Currently, as mathjax3-react specifies React v17 in its peer dependencies, the following error is caused when used with React v18, which this patch aims to solve. 
```
$ npm install mathjax3-react
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR!
npm ERR! While resolving: (redacted)
npm ERR! Found: react@18.2.0
npm ERR! node_modules/react
npm ERR!   react@"^18.2.0" from the root project
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer react@"^17.0.2" from mathjax3-react@1.1.0
npm ERR! node_modules/mathjax3-react
npm ERR!   mathjax3-react@"*" from the root project
npm ERR!
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR!
npm ERR!
npm ERR! For a full report see:
npm ERR! /Users/takeshi/.npm/_logs/2023-05-22T00_41_27_358Z-eresolve-report.txt

npm ERR! A complete log of this run can be found in: /Users/takeshi/.npm/_logs/2023-05-22T00_41_27_358Z-debug-0.log
```
